### PR TITLE
Fix the Behaviors of the Red Slider and the Blue Sider

### DIFF
--- a/images.py
+++ b/images.py
@@ -25,11 +25,12 @@ def remove_bg(alpha: np.ndarray,
               fg: np.ndarray, 
               bg_color: Tuple[int, int, int]) -> Image.Image:
     bg_image = np.zeros(fg.shape, dtype=np.uint8)
-    bg_image[:] = bg_color
+    bg_image[:] = tuple(reversed(bg_color))
     com = alpha * fg + (1 - alpha) * bg_image
     com = com.astype('uint8')
+    output = cv2.cvtColor(com, cv2.COLOR_BGR2RGB)
 
-    return Image.fromarray(com).convert('RGB')
+    return Image.fromarray(output).convert('RGB')
 
 def default_bg(img: str) -> Image.Image:
     output = cv2.cvtColor(readb64(img), cv2.COLOR_BGR2RGB)

--- a/images.py
+++ b/images.py
@@ -28,9 +28,8 @@ def remove_bg(alpha: np.ndarray,
     bg_image[:] = bg_color
     com = alpha * fg + (1 - alpha) * bg_image
     com = com.astype('uint8')
-    output = cv2.cvtColor(com, cv2.COLOR_BGR2RGB)
 
-    return Image.fromarray(output).convert('RGB')
+    return Image.fromarray(com).convert('RGB')
 
 def default_bg(img: str) -> Image.Image:
     output = cv2.cvtColor(readb64(img), cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
Fixes #1 .

Now the red slider controls the red color instead of the blue color.

![Screenshot from 2024-02-27 16-32-04](https://github.com/filnow/bg-changer/assets/4391973/8dbafb38-bc89-4879-971c-257e73ca54e0)

The blue slider controls the blue color instead of the red color.
![Screenshot from 2024-02-27 16-32-18](https://github.com/filnow/bg-changer/assets/4391973/8fa57e36-3073-444b-bfea-544d3607dcb3)
